### PR TITLE
Add support for amp-access

### DIFF
--- a/example/stories/amp-access.stories.js
+++ b/example/stories/amp-access.stories.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export default {
+  title: 'Components/amp-access',
+};
+
+export const hide = () => (
+  <div>
+    <h2>Box hidden</h2>
+    <div style={{ background: '#f00', height: '10rem', width: '10rem' }} amp-access='' amp-access-hide='' />
+  </div>
+);
+
+export const conditional = () => (
+  <div>
+    <h2>Red box hidden</h2>
+    <div style={{ background: '#f00', height: '10rem', width: '10rem' }} amp-access='NOT hasAccess' />
+    <h2>Blue box shown</h2>
+    <div style={{ background: '#00f', height: '10rem', width: '10rem' }} amp-access='hasAccess' />
+  </div>
+);
+conditional.story = {
+  parameters: {
+    amp: {
+      scripts: [
+        `
+        <script id="amp-access" type="application/json">
+          { "authorization": "https://www.mocky.io/v2/5ebc88943100006f005b0bc0", "noPingback": "true" }
+        </script>
+        `
+      ]
+    }
+  }
+}

--- a/src/decorator/index.js
+++ b/src/decorator/index.js
@@ -15,6 +15,7 @@ const getAmpHTML = (story, data = {}, templateFunc = defaultAMPHtmlTemplate) => 
     story,
     title: data && data.title,
     styles: data && data.styles && typeof data.styles === 'string' ? data.styles : '',
+    scripts: data && data.scripts,
   }
   let storyContent = ReactDOMServer.renderToStaticMarkup(story());
 
@@ -43,7 +44,7 @@ const withAmpReactSsrDecorator = (storyFn, context = {}, { parameters }) => {
     return storyFn();
   }
 
-  const ampHtml = getAmpHTML(storyFn, { title: 'AMP Demo', styles });
+  const ampHtml = getAmpHTML(storyFn, { title: 'AMP Demo', styles, scripts });
   const blodURL = getBlodURL(ampHtml, 'text/html');
 
   /* *************** */

--- a/src/decorator/templates/defaultAMPHtmlTemplate.js
+++ b/src/decorator/templates/defaultAMPHtmlTemplate.js
@@ -1,7 +1,8 @@
 export default ({
   styles,
   title='AMP Demo',
-  canonical='#'
+  canonical='#',
+  scripts=[]
 }) => (
 `<!doctype html>
 <html amp lang="en">
@@ -16,6 +17,9 @@ export default ({
     <style amp-custom>${styles}</style>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 
+    ${scripts.map(script => scripts).join('\n')}
+
+    <script async custom-element='amp-access' src='https://cdn.ampproject.org/v0/amp-access-0.1.js'></script>
     <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
     <script async custom-element="amp-user-notification" src="https://cdn.ampproject.org/v0/amp-user-notification-0.1.js"></script>
     <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>


### PR DESCRIPTION
Include [amp-access](https://amp.dev/documentation/components/amp-access) component with a mock authorisation server response and story with conditions.

Use pre-existing unused `scripts` parameter which provides a list of script HTML strings to include in the preview HTML head.