### PR TITLE
chore: add `@emotion/styled` and `@emotion/react` as it is used as a dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "@storybook/addons": "^6.0.0",
     "@storybook/components": "^6.0.0",
     "@storybook/core-events": "^6.0.0",
-    "@emotion/styled": "11.10.4",
+    "@emotion/react": "^11.9.0",
+    "@emotion/styled": "^11.8.1",
     "global": "^4.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@storybook/addons": "^6.0.0",
     "@storybook/components": "^6.0.0",
     "@storybook/core-events": "^6.0.0",
+    "@emotion/styled": "11.10.4",
     "global": "^4.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description 

Do we need to add `@emotion/styled` and  `@emotion/react` as a dependency ?  https://github.com/onwidget/storybook-amp/issues/8
As it's used in UI components 